### PR TITLE
only add repo once to pacman.conf

### DIFF
--- a/roles/fonts/tasks/infinality.yml
+++ b/roles/fonts/tasks/infinality.yml
@@ -1,12 +1,6 @@
 ---
 - name: Add Infinality repository to pacman
-  lineinfile: dest=/etc/pacman.conf
-              state=present
-              insertafter=EOF
-              line="{{ item.line }}"
-  with_items:
-    - { line: "\n[infinality-bundle]" }
-    - { line: "Server = http://bohoomil.com/repo/$arch" }
+  command: bash -c "if ! grep -q bohoomil.com/repo /etc/pacman.conf; then printf '\n[infinality-bundle]\nServer = http://bohoomil.com/repo/$arch\n' >> /etc/pacman.conf; fi"
   tags:
     - infinality
 


### PR DESCRIPTION
For some reason, the infinality tag is getting applied twice, and I haven't figured out why... and the 2nd time it runs the 'add repo' command, it appends it a 2nd time, so when 'update package cache' runs, it fails due to the duplicate repo.

Does everything get applied twie for you when you apply this tag?

This diff will make it idempotent.
