### PR TITLE
Validate sudoers file before copying

### DIFF
--- a/roles/base/tasks/sudo.yml
+++ b/roles/base/tasks/sudo.yml
@@ -10,6 +10,6 @@
     - sudo
 
 - name: Copy sudo configuration
-  template: src=sudoers.j2 dest=/etc/sudoers mode=440
+  template: src=sudoers.j2 dest=/etc/sudoers mode=440 validate='visudo -cf %s'
   tags:
     - sudo


### PR DESCRIPTION
Ansible `copy` module has `validation` parameter that allows to validate the file prior to replacing it on remote:

> The validation command to run before copying into place. The path to the file to validate is passed in via '%s' which must be present as in the example below. The command is passed securely so shell features like expansion and pipes won't work.

Here we use `visudo` to validate the file before writing it in place, so the user won't lock himself out in case of incorrect changes to `sudoers.j2` template.
