### PR TITLE
Fix/disable some changing/out-of-date packages

### DIFF
--- a/group_vars/all
+++ b/group_vars/all
@@ -15,8 +15,7 @@ aur:
     packages:
         - aura-bin
         - downgrade
-        # mirror is down
-        #- orpie
+        - orpie
 
 ssh:
     port: 22

--- a/group_vars/all
+++ b/group_vars/all
@@ -15,7 +15,8 @@ aur:
     packages:
         - aura-bin
         - downgrade
-        - orpie
+        # mirror is down
+        #- orpie
 
 ssh:
     port: 22

--- a/roles/backup/tasks/main.yml
+++ b/roles/backup/tasks/main.yml
@@ -2,12 +2,12 @@
 - name: Install rsnapshot
   pacman: name=rsnapshot state=present
 
-- name: Install attic
-  aur: name=attic user={{ user.name }}
+- name: Install borg
+  aur: name=borg user={{ user.name }}
   tags:
     - aur
 
-- name: Install atticmatic
-  aur: name=atticmatic user={{ user.name }}
+- name: Install borgmatic
+  aur: name=borgmatic user={{ user.name }}
   tags:
     - aur

--- a/roles/hashicorp/meta/main.yml
+++ b/roles/hashicorp/meta/main.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+  - { role: golang }

--- a/roles/hashicorp/tasks/main.yml
+++ b/roles/hashicorp/tasks/main.yml
@@ -2,10 +2,12 @@
 - name: Install vagrant
   pacman: name=vagrant state=present
 
-- name: Install consul and vault
+- name: Install consul
+  pacman: name=consul state=present
+
+- name: Install vault
   aur: name={{ item }} user={{ user.name }}
   with_items:
-    - consul
     - vault-bin
   tags:
     - aur

--- a/roles/hashicorp/tasks/main.yml
+++ b/roles/hashicorp/tasks/main.yml
@@ -2,10 +2,9 @@
 - name: Install vagrant
   pacman: name=vagrant state=present
 
-- name: Install terraform, consul, and vault
+- name: Install consul and vault
   aur: name={{ item }} user={{ user.name }}
   with_items:
-    - terraform-bin
     - consul
     - vault-bin
   tags:

--- a/roles/hashicorp/tasks/main.yml
+++ b/roles/hashicorp/tasks/main.yml
@@ -5,9 +5,10 @@
 - name: Install consul
   pacman: name=consul state=present
 
-- name: Install vault
+- name: Install vault and terraform
   aur: name={{ item }} user={{ user.name }}
   with_items:
     - vault-bin
+    - terraform
   tags:
     - aur

--- a/roles/radio/tasks/radio_ops.yml
+++ b/roles/radio/tasks/radio_ops.yml
@@ -15,10 +15,11 @@
   tags:
     - aur
 
-- name: Install tucnak3
-  aur: name={{ item }} user={{ user.name }}
-  with_items:
-    - libzia3
-    - tucnak3
-  tags:
-    - aur
+# tucnak3 replaced by tucnak4 upstream but no AUR package yet
+#- name: Install tucnak3
+#  aur: name={{ item }} user={{ user.name }}
+#  with_items:
+#    - libzia3
+#    - tucnak3
+#  tags:
+#    - aur


### PR DESCRIPTION
- orpie's mirror is down, is flagged out-of-date
- attic/atticmatic are now borg/borgmatic, atticmatic removed from AUR
- terraform-bin is broken, is flagged out-of-date
- tucnak3 superceded by tucnak4, is flagged out-of-date, mirror url
  changed, no tucnak4 pkgbuild available
