### PR TITLE
Couple of small pkg/dep fixes

### DIFF
--- a/roles/office/tasks/main.yml
+++ b/roles/office/tasks/main.yml
@@ -54,8 +54,8 @@
 - name: Install texlive-core
   pacman: name=texlive-core state=present
 
-- name: Install masterpdfeditor-qt5
-  aur: name=masterpdfeditor-qt5 user={{ user.name }}
+- name: Install masterpdfeditor
+  aur: name=masterpdfeditor user={{ user.name }}
   tags:
     - aur
 

--- a/roles/radio/tasks/radio_mgmt.yml
+++ b/roles/radio/tasks/radio_mgmt.yml
@@ -1,5 +1,8 @@
 ---
 - name: Install CHIRP
-  aur: name=chirp user={{ user.name }}
+  aur: name={{ item }} user={{ user.name }}
+  with_items:
+      - hamradio-menus
+      - chirp
   tags:
     - aur

--- a/roles/wormhole/tasks/main.yml
+++ b/roles/wormhole/tasks/main.yml
@@ -6,6 +6,7 @@
       - python-spake2
       - python-humanize
       - python-tqdm
+      - python-ipaddress
       - magic-wormhole
   tags:
     - aur


### PR DESCRIPTION
- chirp requires hamradio-menus
- masterpdfeditor-qt5 is now called masterpdfeditor
- wormhole requires python-ipaddress