### PR TITLE
install cower dependencies before installing cower

### DIFF
--- a/roles/base/tasks/packages.yml
+++ b/roles/base/tasks/packages.yml
@@ -25,6 +25,16 @@
     - aur
     - packages
 
+- name: Install cower dependencies
+  pacman: name={{ item }} state=present
+  with_items:
+    - curl
+    - yajl
+    - perl
+  tags:
+    - aur
+    - packages
+
 - name: Install cower
   aur: name=cower user={{ user.name }} skip_pgp=yes
   tags:


### PR DESCRIPTION
Ran into this earlier today when first using this repository. I was only missing `yajl`, but I figured it makes the most sense to install all of the dependencies just to be safe.

Unsure of whether or not you want these installed somewhere else; simply let me know and I can refactor appropriately.