### PR TITLE
change backitup submodule name to match path

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,7 +4,7 @@
 [submodule "roles/networkmanager/files/nmtrust"]
 	path = roles/networkmanager/files/nmtrust
 	url = https://github.com/pigmonkey/nmtrust.git
-[submodule "roles/cryptshot/files/backitup"]
+[submodule "roles/backitup/files/backitup"]
 	path = roles/backitup/files/backitup
 	url = https://github.com/pigmonkey/backitup
 [submodule "roles/cryptshot/files/cryptshot"]


### PR DESCRIPTION
the path for the submodule was changed in commit 12b1655b6c239c0146b543ebf20f4b6739b86783, but the submodule name was never updated to reflect it.