### PR TITLE
Enable linger for the user

### DIFF
--- a/roles/base/tasks/user.yml
+++ b/roles/base/tasks/user.yml
@@ -20,3 +20,9 @@
   when: user.log.dir is defined
   tags:
     - user
+
+# Lingering is needed to allow to run user service while the user is not logged in.
+- name: Let the user linger
+  command: loginctl enable-linger {{ user.name }}
+  tags:
+    - user


### PR DESCRIPTION
Fixes the problem where "systemctl --user" command fails to run, because the user is not logged in currently.

See also issue https://github.com/pigmonkey/spark/issues/72.