### PR TITLE
Add Gnome Display Manager as an alternative

### DIFF
--- a/group_vars/all
+++ b/group_vars/all
@@ -208,3 +208,12 @@ himawaripy:
     flags: --auto-offset --level 4
 
 middle_click_scroll: True
+
+display_manager: lightdm
+gdm:
+    sound: False
+    font_scaling_factor: 1
+    logo_path: False
+    touchpad:
+        tap_to_click: True
+    accessibility_menu: True

--- a/playbook.yml
+++ b/playbook.yml
@@ -12,7 +12,8 @@
     - { role: ssd, tags: ['ssd'] }
     - { role: fonts, tags: ['fonts'] }
     - { role: x, tags: ['x'] }
-    - { role: lightdm, tags: ['lightdm'] }
+    - { role: lightdm, tags: ['lightdm'], when: "display_manager == 'lightdm'" }
+    - { role: gdm, tags: ['gdm'], when: "display_manager == 'gdm'" }
     - { role: i3, tags: ['i3'] }
     - { role: pass, tags: ['pass'] }
     - { role: iptables, tags: ['iptables'] }

--- a/roles/gdm/files/profile/gdm
+++ b/roles/gdm/files/profile/gdm
@@ -1,0 +1,3 @@
+user-db:user
+system-db:gdm
+file-db:/usr/share/gdm/greeter-dconf-defaults

--- a/roles/gdm/handlers/main.yml
+++ b/roles/gdm/handlers/main.yml
@@ -1,0 +1,3 @@
+---
+- name: update DConf database
+  command: dconf update

--- a/roles/gdm/tasks/main.yml
+++ b/roles/gdm/tasks/main.yml
@@ -1,0 +1,16 @@
+---
+- name: Install GNOME Display Manager (GDM)
+  pacman: name=gdm state=present
+
+- name: Enable GDM
+  service: name=gdm.service enabled=yes
+
+- name: Creating DConf configuratioin profile
+  copy: src=profile/gdm dest=/etc/dconf/profile/gdm
+
+- name: Creating gdm.d directory for DConf
+  file: path=/etc/dconf/db/gdm.d state=directory mode=0644
+
+- name: Configuring GDM
+  template: src=gdm.d/00-spark.j2 dest=/etc/dconf/db/gdm.d/00-spark
+  notify: update DConf database

--- a/roles/gdm/templates/gdm.d/00-spark.j2
+++ b/roles/gdm/templates/gdm.d/00-spark.j2
@@ -1,0 +1,22 @@
+# This configuration file is created by Ansible. Manual changes would get lost.
+
+# Log-in screen logo
+[org/gnome/login-screen]
+{% if gdm.logo_path %}
+logo='{{ gdm.logo_path }}'
+{% endif %}
+
+[org/gnome/desktop/interface]
+# Larger font for log-in screen
+text-scaling-factor={{ gdm.font_scaling_factor | default(1) }}
+
+# Enable Accessibility menu
+toolkit-accessibility={{ gdm.accessibility_menu | ternary('true', 'false') }}
+
+# Turning the sound on/off
+[org/gnome/desktop/sound]
+event-sounds={{ gdm.sound | ternary('true', 'false') }}
+
+# Enable tap-to-click
+[org/gnome/desktop/peripherals/touchpad]
+tap-to-click={{ gdm.touchpad.tap_to_click | ternary('true', 'false') }}


### PR DESCRIPTION
Chanelog

- Add ability to install [GDM](https://wiki.archlinux.org/index.php/GDM) as a graphical login prompt.
- Also certain global settings can be changed by Ansible variables. See "_gdm_" key of **group-vars/all** file.