### PR TITLE
install light from main repos (promoted from AUR)

### DIFF
--- a/roles/laptop/tasks/main.yml
+++ b/roles/laptop/tasks/main.yml
@@ -27,7 +27,6 @@
   service: name=lowbatt.timer enabled=yes state=started
 
 - name: Install light
-  aur: name=light user={{ user.name }}
+  pacman: name=light state=present
   tags:
-    - aur
     - light


### PR DESCRIPTION
`light` moved from the AUR to the main pacman repos a while back. Trivial change :)