### PR TITLE
Include disk space size if you want to test drive 'Spark` on a VM

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,10 @@ from the playbook or by skipping the `laptop` tag.
 If Spark is run on either a ThinkPad or a MacBook, it will detect this and
 execute platform-specific tasks.
 
+**NOte:** If you would like to try recreating all the tasks that are currently 
+included in the ansible playbook, through a VM, you would need a disk of at least 
+**16GB** in size.  
+
 ## Running
 
 First, sync mirrors and install Ansible:


### PR DESCRIPTION
Before I actually try your ansible scripts on an actual physical machine, I tried running it on a VM first.

Being stingy with the disk space requirements, I initially created an 8GB volume for root.  But running the default ansible tasks quickly filled in the disk, and I had to restart from scratch.

I then tried 12GB, but it was **still** NOT enough.

To save the trouble on other people that might want to also testdrive `Spark` I added the following section.

Feel free to drop it, if you do not like it!

Thanks for a nice set of Ansible recipes, btw!
