### PR TITLE
Install bitlbee from aur

### DIFF
--- a/roles/bitlbee/tasks/main.yml
+++ b/roles/bitlbee/tasks/main.yml
@@ -3,7 +3,9 @@
   pacman: name=libotr state=present
 
 - name: Install Bitlbee
-  pacman: name=bitlbee state=present
+  aur: name=bitlbee state=present
+  tags:
+    - aur
 
 - name: Push Bitlbee configuration file
   template: src=bitlbee.conf.j2 dest=/etc/bitlbee/bitlbee.conf


### PR DESCRIPTION
I had issues with bitlbee installation, regrading archwiki they suggest install it from AUR right now:
https://wiki.archlinux.org/title/Bitlbee

Also I can't install it using pacman:
```
sudo pacman -S bitlbee
error: target not found: bitlbee
```