### PR TITLE
Enable autorandr services

### DIFF
--- a/roles/x/tasks/autorandr.yml
+++ b/roles/x/tasks/autorandr.yml
@@ -11,12 +11,3 @@
     daemon_reload: true
   tags:
     - autorandr
-
-- name: Enable autorandr-lid-listener.service to ensure it starts after closing/opening lid
-  ansible.builtin.systemd:
-    name: autorandr-lid-listener.service
-    enabled: true
-    state: started
-    daemon_reload: true
-  tags:
-    - autorandr

--- a/roles/x/tasks/autorandr.yml
+++ b/roles/x/tasks/autorandr.yml
@@ -3,3 +3,20 @@
   pacman: name=autorandr state=present
   tags:
     - autorandr
+
+- name: Enable autorandr.service to ensure it starts after wake from suspend
+  ansible.builtin.systemd:
+    name: autorandr
+    enabled: true
+    daemon_reload: true
+  tags:
+    - autorandr
+
+- name: Enable autorandr-lid-listener.service to ensure it starts after closing/opening lid
+  ansible.builtin.systemd:
+    name: autorandr-lid-listener.service
+    enabled: true
+    state: started
+    daemon_reload: true
+  tags:
+    - autorandr


### PR DESCRIPTION
In laptop case there are some troubles when you have external monitor and unplug it when laptop sleeps. In that case you have blank screen.

To prevent this autorandr team prepared [autorandr.service](https://github.com/phillipberndt/autorandr/blob/master/contrib/systemd/autorandr.service).

Another case is necessity for autorandr to start automatically when lid is closed or opened. Autorandr team prepared [autorandr-lid-listener.service](https://github.com/phillipberndt/autorandr/blob/master/contrib/systemd/autorandr-lid-listener.service).

Both services are part of [autorandr arch linux package](https://archlinux.org/packages/community/any/autorandr/). So the only thing that is left: to enable them.