### PR TITLE
[fprintd] add ability to press enter and proceed to fingerprint authentication.

### DIFF
--- a/roles/thinkpad/templates/pam.d/sudo.j2
+++ b/roles/thinkpad/templates/pam.d/sudo.j2
@@ -1,5 +1,6 @@
 {% if fingerprint == True %}
-auth            sufficient      pam_fprintd.so
+auth		sufficient  	pam_unix.so try_first_pass likeauth nullok
+auth		sufficient  	pam_fprintd.so
 {% endif %}
 auth            include         system-auth
 account         include         system-auth


### PR DESCRIPTION
According to Arch Wiki and issue #106:

> Adding pam_fprintd.so as sufficient to any configuration file in /etc/pam.d/ when a fingerprint signature is present will only prompt for fingerprint authentication. This prevents the use of a password if you cannot Ctrl+c fingerprint authentication (due to the lack of a shell). In order to use either a password or a fingerprint in a graphical interface, add the following line to the top of any files required:
> 
> ```
> auth		sufficient  	pam_unix.so try_first_pass likeauth nullok
> auth		sufficient  	pam_fprintd.so
> ...
> ```
> 
> This will prompt for a password; pressing Enter on a blank field will proceed to fingerprint authentication.

This PR is adding missing line.